### PR TITLE
Allow zero components in UID validation

### DIFF
--- a/Sources/DcmSwift/Foundation/UID.swift
+++ b/Sources/DcmSwift/Foundation/UID.swift
@@ -58,18 +58,15 @@ public class UID {
         }
         
         for partString in uidSplit {
-            
-            // contains only digits
-            guard let _ = Int(partString) else {
+
+            // components must not be empty and should contain only digits
+            guard !partString.isEmpty, let _ = Int(partString) else {
                 Logger.error("UID \(uid) needs to be made of integers")
                 return false
             }
-            
-            //1st char of a part cannot be a `0`
-            guard let partInt = Int(partString.prefix(1)) else {
-                return false
-            }
-            if partInt == 0 {
+
+            // components with more than one digit cannot start with '0'
+            if partString.count > 1 && partString.hasPrefix("0") {
                 Logger.error("UID \(uid) parts cannot start by '0' digit")
                 return false
             }

--- a/Tests/DcmSwiftTests/DcmSwiftTestsUID.swift
+++ b/Tests/DcmSwiftTests/DcmSwiftTestsUID.swift
@@ -15,10 +15,14 @@ class DcmSwiftTestsUID: XCTestCase {
     public func testValidateUID() {
         let valUID = "1.102.99"
         XCTAssertTrue(UID.validate(uid: valUID))
-        
+
+        // component "0" should be considered valid
+        let valUIDWithZero = "1.2.840.10008.0.1.1"
+        XCTAssertTrue(UID.validate(uid: valUIDWithZero))
+
         let invalUID1 = "1.012.5"
         let invalUID2 = "coucou"
-        
+
         XCTAssertFalse(UID.validate(uid: invalUID1))
         XCTAssertFalse(UID.validate(uid: invalUID2))
     }


### PR DESCRIPTION
## Summary
- permit UID components equal to zero
- add test covering UID with zero component

## Testing
- `swift test` *(fails: cannot find CoreGraphics/FoundationNetworking types)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2627564c832ebf25cae64a82a2bf