### PR TITLE
Optimize Metal window-level pipeline for better parallelism

### DIFF
--- a/Sources/DcmSwift/Graphics/MetalAccelerator.swift
+++ b/Sources/DcmSwift/Graphics/MetalAccelerator.swift
@@ -18,6 +18,7 @@ public final class MetalAccelerator {
     public let device: MTLDevice?
     public let library: MTLLibrary?
     public let windowLevelPipelineState: MTLComputePipelineState?
+    public let commandQueue: MTLCommandQueue?
 
     public var isAvailable: Bool { windowLevelPipelineState != nil }
 
@@ -25,17 +26,18 @@ public final class MetalAccelerator {
         let debug = UserDefaults.standard.bool(forKey: "settings.debugLogsEnabled")
         // Allow opt-out via env/UD flag
         if ProcessInfo.processInfo.environment["DCMSWIFT_DISABLE_METAL"] == "1" {
-            device = nil; library = nil; windowLevelPipelineState = nil
+            device = nil; library = nil; windowLevelPipelineState = nil; commandQueue = nil
             if debug { print("[MetalAccelerator] Disabled via DCMSWIFT_DISABLE_METAL=1") }
             return
         }
 
         guard let dev = MTLCreateSystemDefaultDevice() else {
-            device = nil; library = nil; windowLevelPipelineState = nil
+            device = nil; library = nil; windowLevelPipelineState = nil; commandQueue = nil
             if debug { print("[MetalAccelerator] No Metal device available") }
             return
         }
         device = dev
+        commandQueue = dev.makeCommandQueue()
 
         // Load the module's compiled metallib. Prefer the modern API that understands SPM bundles.
         var lib: MTLLibrary? = nil


### PR DESCRIPTION
## Summary
- reuse a shared Metal command queue
- dispatch Metal threads in grouped fashion and write results directly into the output buffer

## Testing
- `./test.sh`
- `swift test` *(fails: no such module 'Network')*

------
https://chatgpt.com/codex/tasks/task_e_68bfa127c2bc832eb73015c3e50de8ca