### PR TITLE
Fix dataset flags and group length for C-MOVE and C-GET RQ

### DIFF
--- a/Sources/DcmSwift/Networking/PDU/Messages/DIMSE/CGetRQ.swift
+++ b/Sources/DcmSwift/Networking/PDU/Messages/DIMSE/CGetRQ.swift
@@ -47,18 +47,22 @@ public class CGetRQ: DataTF {
         let commandDataset = DataSet()
         _ = commandDataset.set(value: CommandField.C_GET_RQ.rawValue, forTagName: "CommandField")
         _ = commandDataset.set(value: abstractSyntax, forTagName: "AffectedSOPClassUID")
-        _ = commandDataset.set(value: UInt16(1), forTagName: "MessageID")
+        _ = commandDataset.set(value: self.messageID, forTagName: "MessageID")
         _ = commandDataset.set(value: UInt16(0), forTagName: "Priority") // MEDIUM
 
         if hasDataset {
-            _ = commandDataset.set(value: UInt16(0x0001), forTagName: "CommandDataSetType")
+            // 0x0101 indicates that a dataset follows
+            _ = commandDataset.set(value: UInt16(0x0101), forTagName: "CommandDataSetType")
         } else {
             _ = commandDataset.set(value: UInt16(0x0102), forTagName: "CommandDataSetType")
         }
-        
-        // 4. Serialize the command dataset
+
+        // Insert placeholder for CommandGroupLength at the beginning
+        _ = commandDataset.set(value: UInt32(0), forTagName: "CommandGroupLength")
+
+        // Compute actual group length excluding the CommandGroupLength element itself (12 bytes)
         var commandData = commandDataset.toData(transferSyntax: commandTransferSyntax)
-        let commandLength = commandData.count
+        let commandLength = commandData.count - 12
         _ = commandDataset.set(value: UInt32(commandLength), forTagName: "CommandGroupLength")
         commandData = commandDataset.toData(transferSyntax: commandTransferSyntax)
         

--- a/Sources/DcmSwift/Networking/PDU/Messages/DIMSE/CMoveRQ.swift
+++ b/Sources/DcmSwift/Networking/PDU/Messages/DIMSE/CMoveRQ.swift
@@ -47,19 +47,23 @@ public class CMoveRQ: DataTF {
         let commandDataset = DataSet()
         _ = commandDataset.set(value: CommandField.C_MOVE_RQ.rawValue, forTagName: "CommandField")
         _ = commandDataset.set(value: abstractSyntax, forTagName: "AffectedSOPClassUID")
-        _ = commandDataset.set(value: UInt16(1), forTagName: "MessageID")
+        _ = commandDataset.set(value: self.messageID, forTagName: "MessageID")
         _ = commandDataset.set(value: UInt16(0), forTagName: "Priority") // MEDIUM
         _ = commandDataset.set(value: moveDestinationAET, forTagName: "MoveDestination")
 
         if hasDataset {
-            _ = commandDataset.set(value: UInt16(0x0001), forTagName: "CommandDataSetType")
+            // 0x0101 indicates that a dataset is present as required by the DICOM standard
+            _ = commandDataset.set(value: UInt16(0x0101), forTagName: "CommandDataSetType")
         } else {
             _ = commandDataset.set(value: UInt16(0x0102), forTagName: "CommandDataSetType")
         }
-        
-        // 4. Serialize the command dataset
+
+        // The CommandGroupLength element must be first; insert a placeholder before computing the length
+        _ = commandDataset.set(value: UInt32(0), forTagName: "CommandGroupLength")
+
+        // Serialize once to compute the actual group length (excluding the element itself)
         var commandData = commandDataset.toData(transferSyntax: commandTransferSyntax)
-        let commandLength = commandData.count
+        let commandLength = commandData.count - 12
         _ = commandDataset.set(value: UInt32(commandLength), forTagName: "CommandGroupLength")
         commandData = commandDataset.toData(transferSyntax: commandTransferSyntax)
         


### PR DESCRIPTION
## Summary
- Ensure C-MOVE-RQ encodes message ID, dataset presence flag, and CommandGroupLength per DICOM standard
- Align C-GET-RQ dataset handling and CommandGroupLength computation with standard requirements

## Testing
- `./test.sh`
- `swift test` *(fails: no such module 'Network')*


------
https://chatgpt.com/codex/tasks/task_e_68bfa2058234832e904d3457a0b9927d