### PR TITLE
Optimize Metal window-level pipeline for better parallelism

### DIFF
--- a/Sources/DcmSwift/Graphics/DicomPixelView.swift
+++ b/Sources/DcmSwift/Graphics/DicomPixelView.swift
@@ -424,6 +424,10 @@ public final class DicomPixelView: UIView {
 
     private func applyWindowTo16GPU(_ src: [UInt16], into dst: inout [UInt8]) -> Bool {
         let numPixels = imgWidth * imgHeight
+        guard src.count >= numPixels, dst.count >= numPixels else {
+            print("[DicomPixelView] Error: pixel buffers too small. Expected \(numPixels), got src: \(src.count) dst: \(dst.count)")
+            return false
+        }
         return dst.withUnsafeMutableBufferPointer { outBuf in
             src.withUnsafeBufferPointer { inBuf in
                 processPixelsGPU(inputPixels: inBuf.baseAddress!,


### PR DESCRIPTION
## Summary
- prefer Metal for 16-bit windowing and only build LUTs on CPU fallback
- dispatch GPU threads directly with reused command queue and lighter argument setup
- restore safety check for 16-bit GPU path by validating buffer sizes before windowing

## Testing
- `./test.sh`
- `swift test` *(fails: no such module 'Network')*


------
https://chatgpt.com/codex/tasks/task_e_68bfa840ff88832eb968ca3357a8e54d