### PR TITLE
Use memory-mapped Data for faster input streams

### DIFF
--- a/Sources/DcmSwift/IO/OffsetInputStream.swift
+++ b/Sources/DcmSwift/IO/OffsetInputStream.swift
@@ -35,18 +35,34 @@ public class OffsetInputStream {
      Init a DicomInputStream with a file path
      */
     public init(filePath:String) {
-        stream      = InputStream(fileAtPath: filePath)
-        backstream  = InputStream(fileAtPath: filePath)
-        total       = Int(DicomFile.fileSize(path: filePath))
+        let url = URL(fileURLWithPath: filePath)
+
+        // OPTIMIZATION: Memory-map file for faster sequential access when possible
+        if let data = try? Data(contentsOf: url, options: .mappedIfSafe) {
+            stream     = InputStream(data: data)
+            backstream = InputStream(data: data)
+            total      = data.count
+        } else {
+            stream      = InputStream(fileAtPath: filePath)
+            backstream  = InputStream(fileAtPath: filePath)
+            total       = Int(DicomFile.fileSize(path: filePath))
+        }
     }
-    
+
     /**
     Init a DicomInputStream with a file URL
     */
     public init(url:URL) {
-        stream      = InputStream(url: url)
-        backstream  = InputStream(url: url)
-        total       = Int(DicomFile.fileSize(path: url.path))
+        // OPTIMIZATION: Attempt to memory-map the file
+        if let data = try? Data(contentsOf: url, options: .mappedIfSafe) {
+            stream     = InputStream(data: data)
+            backstream = InputStream(data: data)
+            total      = data.count
+        } else {
+            stream      = InputStream(url: url)
+            backstream  = InputStream(url: url)
+            total       = Int(DicomFile.fileSize(path: url.path))
+        }
     }
     
     /**
@@ -87,33 +103,29 @@ public class OffsetInputStream {
      - Returns: the data read in the stream, or nil
      */
     public func read(length:Int) -> Data? {
-        // Validate length to prevent crashes
-        guard length > 0 && length < Int.max / 2 else {
+        // Validate length to prevent crashes and out-of-bounds reads
+        guard length > 0 && length <= readableBytes else {
             Logger.warning("Invalid read length: \(length)")
             return nil
         }
         
-        // allocate memory buffer with given length
-        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: length)
-        defer {
-            // Always clean the memory, even on failure
-            buffer.deallocate()
+        // Avoid extra allocations by reading directly into a Data buffer
+        var data = Data(count: length)
+        let read = data.withUnsafeMutableBytes { ptr -> Int in
+            guard let base = ptr.bindMemory(to: UInt8.self).baseAddress else {
+                return -1
+            }
+            return stream.read(base, maxLength: length)
         }
-        
-        // fill the buffer by reading bytes with given length
-        let read = stream.read(buffer, maxLength: length)
-        
-        if read < 0 || read < length {
-            //Logger.warning("Cannot read \(length) bytes")
+
+        // Bail out if the stream didn't deliver the requested bytes
+        if read < length {
             return nil
         }
-        
-        // create a Data object with filled buffer
-        let data = Data(bytes: buffer, count: length)
-        
+
         // maintain local offset
         offset += read
-        
+
         return data
     }
 


### PR DESCRIPTION
## Summary
- use memory-mapped `Data` when creating `OffsetInputStream` from file paths or URLs
- read directly into a `Data` buffer to avoid extra allocation when pulling bytes

## Testing
- `bash test.sh`
- `swift test` *(fails: no such module 'Network')*


------
https://chatgpt.com/codex/tasks/task_e_68bfad9ea834832e8af2582e00d8456e