### PR TITLE
feat: add Metal buffer cache and RGB support

### DIFF
--- a/Sources/DcmSwift/Graphics/Metal/BufferCache.swift
+++ b/Sources/DcmSwift/Graphics/Metal/BufferCache.swift
@@ -1,0 +1,43 @@
+#if canImport(Metal)
+import Metal
+import Foundation
+
+/// Simple cache for reusing `MTLBuffer` instances across frames.
+/// Buffers are keyed by their length and stored in a pool so that
+/// subsequent frames can reuse them without incurring allocation cost.
+final class MetalBufferCache {
+    static let shared = MetalBufferCache(device: MetalAccelerator.shared.device)
+
+    private let device: MTLDevice?
+    private var cache: [Int: [MTLBuffer]] = [:]
+    private let lock = NSLock()
+
+    init(device: MTLDevice?) {
+        self.device = device
+    }
+
+    /// Retrieve a buffer of at least `length` bytes. A cached buffer will be
+    /// returned if available, otherwise a new one is created.
+    func buffer(length: Int) -> MTLBuffer? {
+        lock.lock(); defer { lock.unlock() }
+        if var existing = cache[length], !existing.isEmpty {
+            let buf = existing.removeLast()
+            cache[length] = existing
+            return buf
+        }
+        return device?.makeBuffer(length: length, options: .storageModeShared)
+    }
+
+    /// Return a buffer to the cache for reuse.
+    func recycle(_ buffer: MTLBuffer) {
+        lock.lock()
+        cache[buffer.length, default: []].append(buffer)
+        lock.unlock()
+    }
+
+    /// Remove all cached buffers.
+    func purge() {
+        lock.lock(); cache.removeAll(); lock.unlock()
+    }
+}
+#endif

--- a/Tests/DcmSwiftTests/DicomPixelViewIntegrationTests.swift
+++ b/Tests/DcmSwiftTests/DicomPixelViewIntegrationTests.swift
@@ -1,0 +1,20 @@
+#if canImport(UIKit)
+import XCTest
+@testable import DcmSwift
+
+final class DicomPixelViewIntegrationTests: XCTestCase {
+    func testGrayscalePipeline() {
+        let view = DicomPixelView(frame: .zero)
+        let pixels: [UInt8] = [0, 64, 128, 255]
+        view.setPixels8(pixels, width: 2, height: 2, windowWidth: 255, windowCenter: 128)
+        XCTAssertGreaterThan(view.estimatedMemoryUsage(), 0)
+    }
+
+    func testRGBPipeline() {
+        let view = DicomPixelView(frame: .zero)
+        let pixels: [UInt8] = [255, 0, 0, 0, 255, 0, 0, 0, 255, 255, 255, 255]
+        view.setPixelsRGB(pixels, width: 2, height: 2)
+        XCTAssertGreaterThan(view.estimatedMemoryUsage(), 0)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add reusable Metal buffer cache
- extend shader and bindings for RGB/RGBA images
- debounce window/level updates to reduce command buffer churn
- add integration tests for grayscale and RGB pipelines

## Testing
- `swift test` *(fails: no such module 'Network')*


------
https://chatgpt.com/codex/tasks/task_e_68c013d3fa0c832eadc242322b54f3a4