### PR TITLE
feat: stream DICOM pixel data fragments

### DIFF
--- a/Sources/DcmSwift/Graphics/DicomImage.swift
+++ b/Sources/DcmSwift/Graphics/DicomImage.swift
@@ -84,60 +84,86 @@ public class DicomImage {
     
     public init?(_ dataset:DataSet) {
         self.dataset = dataset
-        
+        configureMetadata()
+        self.loadPixelData()
+    }
+
+    /// Initialize a DicomImage by streaming pixel data directly from a DicomInputStream.
+    /// - Parameters:
+    ///   - stream: The input stream to read from.
+    ///   - pixelHandler: Optional handler invoked for each pixel fragment as it is read.
+    public init?(stream: DicomInputStream, pixelHandler: ((Data) -> Bool)? = nil) {
+        var collected:[Data] = []
+        let handler = pixelHandler ?? { fragment in collected.append(fragment); return true }
+
+        guard let ds = try? stream.readDataset(pixelDataHandler: handler) else {
+            return nil
+        }
+
+        self.dataset = ds
+        self.frames = collected
+        configureMetadata()
+
+        if pixelHandler == nil && numberOfFrames == 0 {
+            numberOfFrames = frames.count
+        }
+    }
+
+    /// Extract important metadata from the dataset and populate image properties.
+    private func configureMetadata() {
         if let pi = self.dataset.string(forTag: "PhotometricInterpretation") {
             if pi.trimmingCharacters(in: CharacterSet.whitespaces) == "MONOCHROME1" {
                 self.photoInter = .MONOCHROME1
                 self.isMonochrome = true
-                
+
             } else if pi.trimmingCharacters(in: CharacterSet.whitespaces) == "MONOCHROME2" {
                 self.photoInter = .MONOCHROME2
                 self.isMonochrome = true
-                
+
             } else if pi.trimmingCharacters(in: CharacterSet.whitespaces) == "ARGB" {
                 self.photoInter = .ARGB
-                
+
             } else if pi.trimmingCharacters(in: CharacterSet.whitespaces) == "RGB" {
                 self.photoInter = .RGB
             }
         }
-        
+
         if let v = self.dataset.integer16(forTag: "Rows") {
             self.rows = Int(v)
         }
-        
+
         if let v = self.dataset.integer16(forTag: "Columns") {
             self.columns = Int(v)
         }
-        
+
         if let v = self.dataset.string(forTag: "WindowWidth") {
             self.windowWidth = Int(v) ?? self.windowWidth
         }
-        
+
         if let v = self.dataset.string(forTag: "WindowCenter") {
             self.windowCenter = Int(v) ?? self.windowCenter
         }
-        
+
         if let v = self.dataset.string(forTag: "RescaleSlope") {
             self.rescaleSlope = Int(v) ?? self.rescaleSlope
         }
-        
+
         if let v = self.dataset.string(forTag: "RescaleIntercept") {
             self.rescaleIntercept = Int(v) ?? self.rescaleIntercept
         }
-        
+
         if let v = self.dataset.integer16(forTag: "BitsAllocated") {
             self.bitsAllocated = Int(v)
         }
-        
+
         if let v = self.dataset.integer16(forTag: "BitsStored") {
             self.bitsStored = Int(v)
         }
-        
+
         if let v = self.dataset.integer16(forTag: "SamplesPerPixel") {
             self.samplesPerPixel = Int(v)
         }
-        
+
         if let v = self.dataset.integer16(forTag: "PixelRepresentation") {
             if v == 0 {
                 self.pixelRepresentation = .Unsigned
@@ -145,18 +171,18 @@ public class DicomImage {
                 self.pixelRepresentation = .Signed
             }
         }
-        
+
         if self.dataset.hasElement(forTagName: "PixelData") {
             self.numberOfFrames = 1
         }
-        
+
         if let nofString = self.dataset.string(forTag: "NumberOfFrames") {
             if let nof = Int(nofString) {
                 self.isMultiframe   = true
                 self.numberOfFrames = nof
             }
         }
-        
+
         Logger.verbose("  -> rows : \(self.rows)")
         Logger.verbose("  -> columns : \(self.columns)")
         Logger.verbose("  -> photoInter : \(photoInter)")
@@ -165,8 +191,6 @@ public class DicomImage {
         Logger.verbose("  -> samplesPerPixel : \(samplesPerPixel)")
         Logger.verbose("  -> bitsAllocated : \(bitsAllocated)")
         Logger.verbose("  -> bitsStored : \(bitsStored)")
-        
-        self.loadPixelData()
     }
 
 #if os(macOS)

--- a/Sources/DcmSwift/Networking/DicomEntity.swift
+++ b/Sources/DcmSwift/Networking/DicomEntity.swift
@@ -7,7 +7,9 @@
 //
 
 import Foundation
+#if canImport(Network)
 import Network
+#endif
 
 /**
  A DicomEntity represents a Dicom Applicatin Entity (AE).

--- a/Sources/DcmSwift/Tools/PixelService.swift
+++ b/Sources/DcmSwift/Tools/PixelService.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(os)
 import os
+#endif
 
 /// A lightweight, reusable pixel decoding surface for applications.
 /// Centralizes first-frame extraction and basic pixel buffer preparation.

--- a/Sources/DcmSwift/Tools/ROIMeasurementService.swift
+++ b/Sources/DcmSwift/Tools/ROIMeasurementService.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(CoreGraphics)
 import CoreGraphics
+#endif
 #if canImport(UIKit)
 import UIKit
 #endif

--- a/Tests/DcmSwiftTests/PixelStreamingTests.swift
+++ b/Tests/DcmSwiftTests/PixelStreamingTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import DcmSwift
+
+final class PixelStreamingTests: XCTestCase {
+    func testStreamPixelFragments() {
+        let fragmentCount = 3
+        let fragmentSize = 1024 * 1024 // 1MB each
+
+        var data = Data()
+        // Pixel Data tag (7fe0,0010) with OB VR and undefined length
+        data.append(contentsOf: [0xe0, 0x7f, 0x10, 0x00])
+        data.append(contentsOf: [0x4f, 0x42]) // "OB"
+        data.append(contentsOf: [0x00, 0x00])
+        data.append(contentsOf: [0xff, 0xff, 0xff, 0xff])
+
+        for _ in 0..<fragmentCount {
+            // Item tag FFFE,E000
+            data.append(contentsOf: [0xfe, 0xff, 0x00, 0xe0])
+            // Length
+            let len = UInt32(fragmentSize)
+            data.append(contentsOf: [UInt8(len & 0xff), UInt8((len >> 8) & 0xff), UInt8((len >> 16) & 0xff), UInt8((len >> 24) & 0xff)])
+            data.append(Data(repeating: 0x00, count: fragmentSize))
+        }
+
+        // Sequence delimiter FFFE,E0DD
+        data.append(contentsOf: [0xfe, 0xff, 0xdd, 0xe0])
+        data.append(contentsOf: [0x00, 0x00, 0x00, 0x00])
+
+        let dis = DicomInputStream(data: data)
+        dis.open()
+
+        var count = 0
+        var bytes = 0
+        dis.readPixelDataFragments { fragment in
+            count += 1
+            bytes += fragment.count
+            return true
+        }
+
+        XCTAssertEqual(count, fragmentCount)
+        XCTAssertEqual(bytes, fragmentCount * fragmentSize)
+        dis.close()
+    }
+
+    static var allTests = [
+        ("testStreamPixelFragments", testStreamPixelFragments),
+    ]
+}
+

--- a/Tests/DcmSwiftTests/XCTestManifests.swift
+++ b/Tests/DcmSwiftTests/XCTestManifests.swift
@@ -5,6 +5,7 @@ public func allTests() -> [XCTestCaseEntry] {
     return [
         testCase(DcmSwiftTests.allTests),
         testCase(WindowLevelCalculatorTests.allTests),
+        testCase(PixelStreamingTests.allTests),
     ]
 }
 #endif


### PR DESCRIPTION
## Summary
- add callback-based pixel fragment streaming to `DicomInputStream`
- stream pixel data during `DicomImage` initialization
- add tests for streaming large encapsulated images

## Testing
- `swift test` *(fails: cannot find CoreGraphics/URLRequest on Linux)*

------
https://chatgpt.com/codex/tasks/task_e_68c013d1aac4832eb3baac2921a7a935