### PR TITLE
fix: correct vDSP LUT indexing for 16-bit LUT

### DIFF
--- a/Sources/DcmSwift/Graphics/DicomPixelView.swift
+++ b/Sources/DcmSwift/Graphics/DicomPixelView.swift
@@ -469,6 +469,8 @@ public final class DicomPixelView: UIView {
         if components == 1 {
             var indices = [Float](repeating: 0, count: numPixels)
             vDSP.integerToFloatingPoint(src, result: &indices)
+            var one: Float = 1
+            vDSP_vsadd(indices, 1, &one, &indices, 1, vDSP_Length(numPixels))
             var lutF = [Float](repeating: 0, count: lut.count)
             vDSP.integerToFloatingPoint(lut, result: &lutF)
             var resultF = [Float](repeating: 0, count: numPixels)


### PR DESCRIPTION
## Summary
- offset vDSP_vlint indices by 1 to use correct LUT entries

## Testing
- `swift test` *(fails: 'XMLParser' cannot be constructed; missing FoundationXML, etc.)*
- `swift References/WindowLevelBenchmark.swift`


------
https://chatgpt.com/codex/tasks/task_e_68c01dbe19e8832eba4bba4beb5577e8