### PR TITLE
fix: load contiguous pixel data in stream initializer

### DIFF
--- a/Sources/DcmSwift/Graphics/DicomImage.swift
+++ b/Sources/DcmSwift/Graphics/DicomImage.swift
@@ -108,6 +108,10 @@ public class DicomImage {
         self.frames = collected
         configureMetadata()
 
+        if frames.isEmpty && self.dataset.hasElement(forTagName: "PixelData") {
+            loadPixelData()
+        }
+
         if pixelHandler == nil && numberOfFrames == 0 {
             numberOfFrames = frames.count
         }


### PR DESCRIPTION
## Summary
- load pixel data from dataset when no fragments are streamed

## Testing
- `swift test` *(fails: 'CGColorSpaceCreateDeviceRGB' in scope, 'URLSession' unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c01f3333c4832ea213de5da871569a