### PR TITLE
fix: keep zero-based vDSP LUT indexing

### DIFF
--- a/Sources/DcmSwift/Graphics/DicomPixelView.swift
+++ b/Sources/DcmSwift/Graphics/DicomPixelView.swift
@@ -469,8 +469,6 @@ public final class DicomPixelView: UIView {
         if components == 1 {
             var indices = [Float](repeating: 0, count: numPixels)
             vDSP.integerToFloatingPoint(src, result: &indices)
-            var one: Float = 1
-            vDSP_vsadd(indices, 1, &one, &indices, 1, vDSP_Length(numPixels))
             var lutF = [Float](repeating: 0, count: lut.count)
             vDSP.integerToFloatingPoint(lut, result: &lutF)
             var resultF = [Float](repeating: 0, count: numPixels)


### PR DESCRIPTION
## Summary
- remove addition of 1 to LUT indices before vDSP_vlint so indices remain zero-based

## Testing
- `swift test` *(fails: cannot find type 'CGBitmapInfo' in scope, 'XMLParser' unavailable, etc.)*
- `swift References/WindowLevelBenchmark.swift`


------
https://chatgpt.com/codex/tasks/task_e_68c021b99164832e933606455b702beb