### PR TITLE
Harden frame indexing against malformed BOT offsets

### DIFF
--- a/Sources/DcmSwift/Graphics/DcmSwiftPerformanceMonitor.swift
+++ b/Sources/DcmSwift/Graphics/DcmSwiftPerformanceMonitor.swift
@@ -6,7 +6,14 @@
 //
 
 import Foundation
+
+#if canImport(os)
+import os
+#endif
+
+#if canImport(os.signpost)
 import os.signpost
+#endif
 
 #if canImport(Metal)
 import Metal
@@ -16,27 +23,34 @@ import Metal
 @MainActor
 public final class DcmSwiftPerformanceMonitor {
     public static let shared = DcmSwiftPerformanceMonitor()
-    
+
+#if canImport(os.signpost)
     private let signpostLog: OSLog
     private let enabled: Bool
-    
+#else
+    private let enabled: Bool = false
+#endif
+
     private init() {
+#if canImport(os.signpost)
         self.signpostLog = OSLog(
             subsystem: "com.dcmswift.performance",
             category: "dcmswift"
         )
         self.enabled = UserDefaults.standard.bool(forKey: "settings.perfMetricsEnabled")
+#endif
     }
-    
+
     // MARK: - GPU Operations
-    
+
     public func startGPUOperation(_ operation: GPUOperation) -> GPUOperationToken {
         let token = GPUOperationToken(
             id: UUID(),
             operation: operation,
             startTime: CFAbsoluteTimeGetCurrent()
         )
-        
+
+#if canImport(os.signpost)
         if enabled {
             let signpostID = OSSignpostID(log: signpostLog)
             os_signpost(.begin,
@@ -45,13 +59,15 @@ public final class DcmSwiftPerformanceMonitor {
                        signpostID: signpostID,
                        "Operation: %{public}@", operation.rawValue)
         }
-        
+#endif
+
         return token
     }
-    
+
     public func endGPUOperation(_ token: GPUOperationToken, success: Bool = true) {
         let duration = CFAbsoluteTimeGetCurrent() - token.startTime
-        
+
+#if canImport(os.signpost)
         if enabled {
             let signpostID = OSSignpostID(log: signpostLog)
             os_signpost(.end,
@@ -61,6 +77,10 @@ public final class DcmSwiftPerformanceMonitor {
                        "Operation: %{public}@, Duration: %.3fms, Success: %{public}@",
                        token.operation.rawValue, duration * 1000, success ? "true" : "false")
         }
+#else
+        _ = success
+        _ = duration
+#endif
     }
 }
 


### PR DESCRIPTION
## Summary
- enforce monotonic Basic Offset Table offsets and per-frame size limits when building encapsulated frame indexes
- guard native pixel frame sizing against overflow and oversized frames, adding explicit error cases and regression tests
- make the performance monitor no-op on platforms without `os.signpost` so the package continues to build on Linux

## Testing
- `swift test` *(fails on Linux: CoreGraphics module is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68c886be19cc832e92473c68ec6c550c